### PR TITLE
Update git.js

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -1399,8 +1399,6 @@
 
          spawned.on('close', result.resolve);
 
-         spawned.on('exit', result.resolve);
-
          result.promise.then(function (exitCode) {
             function done (output) {
                then.call(git, null, output);


### PR DESCRIPTION
'Note that when the 'exit' event is triggered, child process stdio streams might still be open.' (https://nodejs.org/api/child_process.html#child_process_event_exit).
It caused trouble with git show.